### PR TITLE
[release] Prepare release core-1.12.1-alpha.1

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.1
+
+Released 2025-Jul-25
+
 ## 1.11.0-rc.1
 
 Released 2024-Dec-11

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.1
+
+Released 2025-Jul-25
+
 ## 1.11.0-rc.1
 
 Released 2024-Dec-11

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.1
+
+Released 2025-Jul-25
+
 ## 1.11.0-rc.1
 
 Released 2024-Dec-11

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.1
+
+Released 2025-Jul-25
+
 ## 1.11.0-rc.1
 
 Released 2024-Dec-11

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.1
+
+Released 2025-Jul-25
+
 ## 1.11.0-rc.1
 
 Released 2024-Dec-11

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.1
+
+Released 2025-Jul-25
+
 ## 1.11.0-rc.1
 
 Released 2024-Dec-11

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.1
+
+Released 2025-Jul-25
+
 ## 1.11.0-rc.1
 
 Released 2024-Dec-11

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -6,6 +6,10 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.1
+
+Released 2025-Jul-25
+
 ## 1.11.0-rc.1
 
 Released 2024-Dec-11

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.1
+
+Released 2025-Jul-25
+
 * [Meter.Tags](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics.meter.tags?view=net-9.0)
   will now be considered when resolving the SDK metric to update when
   measurements are recorded. Meters with the same name and different tags will


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/Kielek/opentelemetry-dotnet/actions/workflows/prepare-release.yml).

Requested by: @Kielek

## Changes

* CHANGELOG files updated for projects being released.
## Commands

`/UpdateReleaseDates`: Use to update release dates in CHANGELOGs before merging [`approvers`, `maintainers`]
`/CreateReleaseTag`: Use after merging to push the release tag and trigger the job to create packages [`approvers`, `maintainers`]
`/PushPackages`: Use after the created packages have been validated to push to NuGet [`maintainers`]