### PR TITLE
[release] Prepare release core-1.12.1-alpha.4

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.4
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.4
+
+Released 2025-Jul-25
+
 * Added `AddLink(SpanContext, SpanAttributes?)` to `TelemetrySpan` to support
   linking spans and associating optional attributes for advanced trace relationships.
   ([#6305](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6305))

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.4
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.4
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.4
+
+Released 2025-Jul-25
+
 * Fixed an issue in .NET Framework where OTLP export of traces, logs, and
   metrics using `OtlpExportProtocol.Grpc` did not correctly set the initial
   write position, resulting in gRPC protocol errors.

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.4
+
+Released 2025-Jul-25
+
 * Removed the peer service resolver, which was based on earlier experimental
   semantic conventions that are not part of the stable specification. This
   change ensures that the exporter no longer modifies or assumes the value of

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.4
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -6,6 +6,10 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.4
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.1-alpha.4
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/Kielek/opentelemetry-dotnet/actions/workflows/prepare-release.yml).

Requested by: @Kielek

## Changes

* CHANGELOG files updated for projects being released.
## Commands

`/UpdateReleaseDates`: Use to update release dates in CHANGELOGs before merging [`approvers`, `maintainers`]
`/CreateReleaseTag`: Use after merging to push the release tag and trigger the job to create packages [`approvers`, `maintainers`]
`/PushPackages`: Use after the created packages have been validated to push to NuGet [`maintainers`]