### PR TITLE
[release] Prepare release core-1.12.2001

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,6 +4,12 @@ This file contains highlights and announcements covering all components.
 For more details see `CHANGELOG.md` files maintained in the root source
 directory of each individual package.
 
+## 1.12.2001
+
+Release details: [1.12.2001](https://github.com/Kielek/opentelemetry-dotnet/releases/tag/core-1.12.2001)
+
+
+
 ## 1.12.0
 
 Release details: [1.12.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.12.0)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -8,7 +8,13 @@ directory of each individual package.
 
 Release details: [1.12.2001](https://github.com/Kielek/opentelemetry-dotnet/releases/tag/core-1.12.2001)
 
-
+* **Breaking Change 2201 by evvar**: `OpenTelemetry.Exporter.OpenTelemetryProtocol` now
+  defaults to using OTLP/HTTP instead of OTLP/gRPC when targeting .NET Framework
+  and .NET Standard. This change may cause telemetry export to fail unless
+  appropriate adjustments are made. Explicitly setting OTLP/gRPC may result in a
+  `NotSupportedException` unless further configuration is applied. See
+  [#6209](https://github.com/open-telemetry/opentelemetry-dotnet/issues/6209) for
+  full details and mitigation guidance. [#6229](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6229)
 
 ## 1.12.0
 

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.2001
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Shipped.txt
@@ -126,6 +126,8 @@ OpenTelemetry.Trace.TelemetrySpan.AddEvent(string! name, OpenTelemetry.Trace.Spa
 OpenTelemetry.Trace.TelemetrySpan.AddEvent(string! name, System.DateTimeOffset timestamp, OpenTelemetry.Trace.SpanAttributes? attributes) -> OpenTelemetry.Trace.TelemetrySpan!
 OpenTelemetry.Trace.TelemetrySpan.AddEvent(string! name, System.DateTimeOffset timestamp) -> OpenTelemetry.Trace.TelemetrySpan!
 OpenTelemetry.Trace.TelemetrySpan.AddEvent(string! name) -> OpenTelemetry.Trace.TelemetrySpan!
+OpenTelemetry.Trace.TelemetrySpan.AddLink(OpenTelemetry.Trace.SpanContext spanContext, OpenTelemetry.Trace.SpanAttributes? attributes) -> OpenTelemetry.Trace.TelemetrySpan!
+OpenTelemetry.Trace.TelemetrySpan.AddLink(OpenTelemetry.Trace.SpanContext spanContext) -> OpenTelemetry.Trace.TelemetrySpan!
 OpenTelemetry.Trace.TelemetrySpan.Context.get -> OpenTelemetry.Trace.SpanContext
 OpenTelemetry.Trace.TelemetrySpan.Dispose() -> void
 OpenTelemetry.Trace.TelemetrySpan.End() -> void

--- a/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,2 +1,0 @@
-OpenTelemetry.Trace.TelemetrySpan.AddLink(OpenTelemetry.Trace.SpanContext spanContext) -> OpenTelemetry.Trace.TelemetrySpan!
-OpenTelemetry.Trace.TelemetrySpan.AddLink(OpenTelemetry.Trace.SpanContext spanContext, OpenTelemetry.Trace.SpanAttributes? attributes) -> OpenTelemetry.Trace.TelemetrySpan!

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.2001
+
+Released 2025-Jul-25
+
 * Added `AddLink(SpanContext, SpanAttributes?)` to `TelemetrySpan` to support
   linking spans and associating optional attributes for advanced trace relationships.
   ([#6305](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6305))

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.2001
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.2001
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.2001
+
+Released 2025-Jul-25
+
 * Fixed an issue in .NET Framework where OTLP export of traces, logs, and
   metrics using `OtlpExportProtocol.Grpc` did not correctly set the initial
   write position, resulting in gRPC protocol errors.

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.2001
+
+Released 2025-Jul-25
+
 * Removed the peer service resolver, which was based on earlier experimental
   semantic conventions that are not part of the stable specification. This
   change ensures that the exporter no longer modifies or assumes the value of

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.2001
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -6,6 +6,10 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.2001
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+## 1.12.2001
+
+Released 2025-Jul-25
+
 ## 1.12.0
 
 Released 2025-Apr-29


### PR DESCRIPTION
Note: This PR was opened automatically by the [prepare release workflow](https://github.com/Kielek/opentelemetry-dotnet/actions/workflows/prepare-release.yml).

Requested by: @Kielek

## Changes

* CHANGELOG files updated for projects being released.
* Public API files updated for projects being released (only performed for stable releases).
## Commands

`/UpdateReleaseDates`: Use to update release dates in CHANGELOGs before merging [`approvers`, `maintainers`]
`/UpdateReleaseNotes`: Use to update `RELEASENOTES.md` before merging [`approvers`, `maintainers`]
`/CreateReleaseTag`: Use after merging to push the release tag and trigger the job to create packages [`approvers`, `maintainers`]
`/PushPackages`: Use after the created packages have been validated to push to NuGet [`maintainers`]