### PR TITLE
[Exporter.Console] Fix inverted metric tag spacing check

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -266,7 +266,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
                 msg.Append(metricPoint.EndTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
                 msg.Append("] ");
                 msg.Append(tags);
-                if (string.IsNullOrEmpty(tags))
+                if (!string.IsNullOrEmpty(tags))
                 {
                     msg.Append(' ');
                 }


### PR DESCRIPTION
### Motivation
- Correct a functional regression in console metric formatting where a separator space was added only when tags were empty, causing metric point output to run together.

### Description
- Change the tag-spacing condition in `src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs` from `if (string.IsNullOrEmpty(tags))` to `if (!string.IsNullOrEmpty(tags))` so a separator space is appended only when `tags` is non-empty.
- Verified that the `metric.Description` and `metric.Unit` checks are already using `!string.IsNullOrEmpty(...)` at HEAD, so no changes were required for those checks.

### Testing
- Attempted to run the console exporter tests with `dotnet test test/OpenTelemetry.Exporter.Console.Tests/OpenTelemetry.Exporter.Console.Tests.csproj --framework net10.0`, but the environment lacks the `dotnet` SDK so tests could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8c5c9f84c83238b83f4e02cefa8a8)