### PR TITLE
Harden persistent storage cleanup against malformed filenames

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageHelper.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageHelper.cs
@@ -40,7 +40,13 @@ internal static class PersistentStorageHelper
             var fileDateTime = GetDateTimeFromLeaseName(filePath);
             if (fileDateTime < leaseDeadline)
             {
-                var newFilePath = filePath.Substring(0, filePath.LastIndexOf('@'));
+                var atSignIndex = filePath.LastIndexOf('@');
+                if (atSignIndex == -1)
+                {
+                    return false;
+                }
+
+                var newFilePath = filePath.Substring(0, atSignIndex);
                 try
                 {
                     File.Move(filePath, newFilePath);
@@ -132,7 +138,13 @@ internal static class PersistentStorageHelper
     internal static DateTime GetDateTimeFromBlobName(string filePath)
     {
         var fileName = GetFileNameWithoutExtension(filePath);
-        var timestamp = fileName.Substring(0, fileName.LastIndexOf('-'));
+        var dashIndex = fileName.LastIndexOf('-');
+        if (dashIndex == -1)
+        {
+            return DateTime.MinValue;
+        }
+
+        var timestamp = fileName.Substring(0, dashIndex);
 
         return Parse(timestamp);
     }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/PersistentStorage/PersistentStorageHelperTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/PersistentStorage/PersistentStorageHelperTests.cs
@@ -49,6 +49,7 @@ public class PersistentStorageHelperTests
     [InlineData("invalid-format.blob")]
     [InlineData("2024-01-15T14:30:25Z-abc123.blob")]
     [InlineData("abc-def.blob")]
+    [InlineData("invalidformat.blob")]
     public void GetDateTimeFromBlobName_InvalidFormat_ReturnsDateTimeMinValue(string filePath)
     {
         var result = PersistentStorageHelper.GetDateTimeFromBlobName(filePath);
@@ -216,5 +217,15 @@ public class PersistentStorageHelperTests
 
         Assert.Equal(result1a, result1b);
         Assert.NotEqual(result1a, result2);
+    }
+
+    [Fact]
+    public void RemoveExpiredLease_WithoutLeaseDelimiter_ReturnsFalse()
+    {
+        var leaseDeadline = DateTime.UtcNow;
+
+        var result = PersistentStorageHelper.RemoveExpiredLease(leaseDeadline, "invalid-format.lock");
+
+        Assert.False(result);
     }
 }


### PR DESCRIPTION
### Motivation
- Persistent storage cleanup assumed filename delimiters (`-` in blob/tmp names and `@` in lock names) and could throw `ArgumentOutOfRangeException` during substring operations, allowing a crafted file in the storage directory to crash maintenance and cause a local DoS.

### Description
- Guard `RemoveExpiredLease` against missing `@` by checking `LastIndexOf('@')` and returning `false` when the delimiter is absent to avoid `Substring(0, -1)`; change applied in `PersistentStorageHelper.RemoveExpiredLease`.
- Guard `GetDateTimeFromBlobName` against missing `-` by checking `LastIndexOf('-')` and returning `DateTime.MinValue` when absent, preserving existing parse-failure semantics; change applied in `PersistentStorageHelper.GetDateTimeFromBlobName`.
- Add unit tests to cover malformed blob names without `-` and a malformed lock name without `@` in `test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/PersistentStorage/PersistentStorageHelperTests.cs`.
- Changes are minimal and localized to `src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageHelper.cs` and the corresponding tests.

### Testing
- Added unit tests in `test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/PersistentStorage/PersistentStorageHelperTests.cs` that assert safe behavior for malformed names (new test cases included).
- Attempted to run the focused tests with `dotnet test test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj --filter "FullyQualifiedName~PersistentStorageHelperTests"`, but the environment did not have `dotnet` installed so the command failed (`dotnet: command not found`) and automated execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0cdcea61083239e36d361c304ac1f)