### PR TITLE
[Prometheus.HttpListener] Fix Stop start/stop race

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -98,7 +98,7 @@ internal sealed class PrometheusHttpListener : IDisposable
     /// </summary>
     public void Stop()
     {
-        CancellationTokenSource? tokenSource;
+        CancellationTokenSource tokenSource;
         Task? workerThread;
 
         lock (this.syncObject)
@@ -111,8 +111,6 @@ internal sealed class PrometheusHttpListener : IDisposable
                 return;
             }
 
-            this.tokenSource = null;
-            this.workerThread = null;
         }
 
         try
@@ -123,6 +121,15 @@ internal sealed class PrometheusHttpListener : IDisposable
         finally
         {
             tokenSource.Dispose();
+
+            lock (this.syncObject)
+            {
+                if (ReferenceEquals(this.tokenSource, tokenSource))
+                {
+                    this.tokenSource = null;
+                    this.workerThread = null;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

- Prevent a start/stop race in `PrometheusHttpListener.Stop()` where instance fields `tokenSource`/`workerThread` were cleared before cancelling and waiting, allowing `WorkerProc()` to observe `this.tokenSource!` as null and throw a `NullReferenceException`.

### Description

- Capture the active `CancellationTokenSource` and worker `Task` under lock and perform `Cancel()`/`Wait()` on the captured token outside the lock to preserve safe ordering.
- Defer clearing the instance fields until after cancellation/wait completes and perform the clear under lock, guarded by `ReferenceEquals` so only the same lifecycle instance is cleared.
- Make the local `tokenSource` non-nullable to reflect the prior `null`-check under lock and avoid dereferencing races.

### Testing

- Attempted to run `dotnet --version` and `dotnet test`, but the environment lacks the .NET SDK (error: `dotnet: command not found`), so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f044810a948323aac186090dae2c05)