### PR TITLE
[sdk] Restore async-flow isolation in SuppressInstrumentationScope

### DIFF
--- a/src/OpenTelemetry/SuppressInstrumentationScope.cs
+++ b/src/OpenTelemetry/SuppressInstrumentationScope.cs
@@ -12,26 +12,21 @@ namespace OpenTelemetry;
 public sealed class SuppressInstrumentationScope : IDisposable
 {
     // An integer value which controls whether instrumentation should be suppressed (disabled).
-    // * null: instrumentation is not suppressed
+    // * 0: instrumentation is not suppressed
     // * Depth = [int.MinValue, -1]: instrumentation is always suppressed
     // * Depth = [1, int.MaxValue]: instrumentation is suppressed in a reference-counting mode
-    private static readonly RuntimeContextSlot<SuppressInstrumentationScope?> Slot = RuntimeContext.RegisterSlot<SuppressInstrumentationScope?>("otel.suppress_instrumentation");
+    private static readonly RuntimeContextSlot<int> Slot = RuntimeContext.RegisterSlot<int>("otel.suppress_instrumentation");
 
-#pragma warning disable CA2213 // Disposable fields should be disposed
-    private readonly SuppressInstrumentationScope? previousScope;
-#pragma warning restore CA2213 // Disposable fields should be disposed
+    private readonly int previousDepth;
     private bool disposed;
 
     internal SuppressInstrumentationScope(bool value = true)
     {
-        this.previousScope = Slot.Get();
-        this.Depth = value ? -1 : 0;
-        Slot.Set(this);
+        this.previousDepth = Slot.Get();
+        Slot.Set(value ? -1 : 0);
     }
 
-    internal static bool IsSuppressed => (Slot.Get()?.Depth ?? 0) != 0;
-
-    internal int Depth { get; private set; }
+    internal static bool IsSuppressed => Slot.Get() != 0;
 
     /// <summary>
     /// Begins a new scope in which instrumentation is suppressed (disabled).
@@ -70,26 +65,11 @@ public sealed class SuppressInstrumentationScope : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Enter()
     {
-        var currentScope = Slot.Get();
-
-        if (currentScope == null)
-        {
-            Slot.Set(
-#pragma warning disable CA2000 // Dispose objects before losing scope
-                new SuppressInstrumentationScope()
-                {
-                    Depth = 1,
-                });
-#pragma warning restore CA2000 // Dispose objects before losing scope
-
-            return 1;
-        }
-
-        var currentDepth = currentScope.Depth;
+        var currentDepth = Slot.Get();
 
         if (currentDepth >= 0)
         {
-            currentScope.Depth = ++currentDepth;
+            Slot.Set(++currentDepth);
         }
 
         return currentDepth;
@@ -100,7 +80,7 @@ public sealed class SuppressInstrumentationScope : IDisposable
     {
         if (!this.disposed)
         {
-            Slot.Set(this.previousScope);
+            Slot.Set(this.previousDepth);
             this.disposed = true;
         }
     }
@@ -108,18 +88,11 @@ public sealed class SuppressInstrumentationScope : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int IncrementIfTriggered()
     {
-        var currentScope = Slot.Get();
+        var currentDepth = Slot.Get();
 
-        if (currentScope == null)
+        if (currentDepth > 0)
         {
-            return 0;
-        }
-
-        var currentDepth = currentScope.Depth;
-
-        if (currentScope.Depth > 0)
-        {
-            currentScope.Depth = ++currentDepth;
+            Slot.Set(++currentDepth);
         }
 
         return currentDepth;
@@ -128,25 +101,11 @@ public sealed class SuppressInstrumentationScope : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int DecrementIfTriggered()
     {
-        var currentScope = Slot.Get();
+        var currentDepth = Slot.Get();
 
-        if (currentScope == null)
+        if (currentDepth > 0)
         {
-            return 0;
-        }
-
-        var currentDepth = currentScope.Depth;
-
-        if (currentScope.Depth > 0)
-        {
-            if (--currentDepth == 0)
-            {
-                Slot.Set(currentScope.previousScope);
-            }
-            else
-            {
-                currentScope.Depth = currentDepth;
-            }
+            Slot.Set(--currentDepth);
         }
 
         return currentDepth;

--- a/test/OpenTelemetry.Tests/SuppressInstrumentationTests.cs
+++ b/test/OpenTelemetry.Tests/SuppressInstrumentationTests.cs
@@ -72,6 +72,27 @@ public class SuppressInstrumentationTests
     }
 
     [Fact]
+    public async Task SuppressInstrumentationReferenceCountDoesNotLeakAcrossAsyncFlow()
+    {
+        Assert.False(Sdk.SuppressInstrumentation);
+        Assert.Equal(1, SuppressInstrumentationScope.Enter());
+
+        await Task.Factory.StartNew(
+            () =>
+            {
+                Assert.True(Sdk.SuppressInstrumentation);
+                Assert.Equal(2, SuppressInstrumentationScope.IncrementIfTriggered());
+                Assert.Equal(1, SuppressInstrumentationScope.DecrementIfTriggered());
+            },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            TaskScheduler.Default);
+
+        Assert.Equal(0, SuppressInstrumentationScope.DecrementIfTriggered());
+        Assert.False(Sdk.SuppressInstrumentation);
+    }
+
+    [Fact]
     public void DecrementIfTriggeredOnlyWorksInReferenceCountingMode()
     {
         // Instrumentation is not suppressed, DecrementIfTriggered is a no op


### PR DESCRIPTION
### Motivation
- A recent change stored a mutable `SuppressInstrumentationScope` object in the runtime context slot, which allowed `AsyncLocal` to share the same instance across `ExecutionContext`s and caused suppression depth to leak between async flows. 
- The goal is to restore per-`ExecutionContext` isolation for suppression depth so child async flows cannot modify the parent flow's suppression count.

### Description
- Replace `RuntimeContextSlot<SuppressInstrumentationScope?>` with `RuntimeContextSlot<int>` so the slot stores an integer depth value instead of a mutable reference, and add `previousDepth` to preserve nesting semantics from `Begin`/`Dispose`.
- Update `Enter`, `IncrementIfTriggered`, and `DecrementIfTriggered` to read and write the integer slot via `Slot.Get()`/`Slot.Set()` instead of mutating a shared object.
- Adjust `IsSuppressed` and `Dispose` to use the integer depth semantics and to restore the previous depth on dispose.
- Add a unit test `SuppressInstrumentationReferenceCountDoesNotLeakAcrossAsyncFlow` to `test/OpenTelemetry.Tests/SuppressInstrumentationTests.cs` which verifies that reference-count increments in a child task do not affect the parent async flow.

### Testing
- Attempted to run targeted tests with `dotnet test test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj --filter "FullyQualifiedName~SuppressInstrumentation"`, but the command failed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- No automated tests were executed here due to the missing .NET SDK; the new test is included and should be executed by CI or locally where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0cee682fc8323b4c4d22f4f767c0f)